### PR TITLE
Add PYTHONPATH to the base runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get -y install \
 # Set environment variables for root.
 
 ENV LD_LIBRARY_PATH=/opt/senzing/g2/lib
+ENV PYTHONPATH=/opt/senzing/g2/sdk/python
 
 # Runtime execution.
 


### PR DESCRIPTION
This prevents anyone else from having to do so and causes no harm to anyone wanting to use the Java API.
