### PR TITLE
#136 CI maintenance: clean up cspell.json and Slack notification wiring

### DIFF
--- a/.github/workflows/docker-push-containers-to-dockerhub.yaml
+++ b/.github/workflows/docker-push-containers-to-dockerhub.yaml
@@ -9,8 +9,6 @@ permissions: {}
 
 jobs:
   docker-push-containers-to-dockerhub:
-    outputs:
-      status: ${{ job.status }}
     permissions:
       attestations: write
       contents: write
@@ -36,10 +34,10 @@ jobs:
 
   slack-notification:
     needs: [docker-push-containers-to-dockerhub]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub.outputs.status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.docker-push-containers-to-dockerhub.outputs.status }}
+      job-status: ${{ needs.docker-push-containers-to-dockerhub.result }}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -11,7 +11,6 @@
     "cooldown",
     "Dockerfiles",
     "dockerhub",
-    "esbenp",
     "ICLA",
     "ignorefile",
     "kernelsam",
@@ -27,5 +26,7 @@
     "testrun",
     "toplevel"
   ],
-  "ignorePaths": [".git/**"]
+  "ignorePaths": [
+    ".git/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- Remove unused words from `.vscode/cspell.json`
- Use `needs.<job>.result` instead of `needs.<job>.outputs.status` for Slack notifications

Closes #136

---

Resolves #136